### PR TITLE
Fix wallet adapter versions and document setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+planetwars/
+.DS_Store
+dist/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# PlanetWars.fun
+
+This project is a sci-fi themed blockchain game demo built with React, Vite and Tailwind CSS.
+
+## Setup
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+Build for production:
+
+```bash
+npm run build
+```
+
+The `dist` folder will contain the compiled site.

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solana/wallet-adapter-react": "^0.18.6",
-    "@solana/wallet-adapter-wallets": "^0.18.6",
-    "@solana/wallet-adapter-react-ui": "^0.18.6",
+    "@solana/wallet-adapter-react": "^0.15.39",
+    "@solana/wallet-adapter-wallets": "^0.19.37",
+    "@solana/wallet-adapter-react-ui": "^0.9.39",
+    "@solana/web3.js": "^1.89.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/ConnectButton.jsx
+++ b/src/components/ConnectButton.jsx
@@ -1,0 +1,28 @@
+import { useWallet } from '@solana/wallet-adapter-react'
+import { useWalletModal } from '@solana/wallet-adapter-react-ui'
+
+export default function ConnectButton() {
+  const { connected, publicKey, disconnect } = useWallet()
+  const { setVisible } = useWalletModal()
+
+  const handleClick = () => {
+    if (connected) {
+      disconnect()
+    } else {
+      setVisible(true)
+    }
+  }
+
+  const label = connected && publicKey
+    ? `${publicKey.toBase58().slice(0,4)}..${publicKey.toBase58().slice(-4)}`
+    : 'Start Your Planet'
+
+  return (
+    <button
+      onClick={handleClick}
+      className="glow bg-neon text-black rounded-full px-8 py-3 text-2xl font-bold uppercase hover:scale-105 transition"
+    >
+      {label}
+    </button>
+  )
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,5 +1,6 @@
-import { useWallet, WalletModalProvider, WalletMultiButton } from '@solana/wallet-adapter-react-ui'
+import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
 import React from 'react'
+import ConnectButton from './ConnectButton'
 
 export default function Hero() {
   return (
@@ -12,7 +13,7 @@ export default function Hero() {
         Command tokenized planets on Solana.<br /> Outmaneuver, attack, and rebuild in the cosmic arena.
       </p>
       <WalletModalProvider>
-        <WalletMultiButton className="glow !bg-neon !text-black !rounded-full !px-8 !py-3 !text-2xl !font-bold !uppercase hover:scale-105 transition" />
+        <ConnectButton />
       </WalletModalProvider>
     </section>
   )

--- a/src/components/RaidLog.jsx
+++ b/src/components/RaidLog.jsx
@@ -1,14 +1,37 @@
 import { useState, useEffect } from 'react'
 
+const planets = ['Andromeda', 'NebulaX', 'Vortexal', 'Singularis']
 const demoLog = [
-  { id: 1, from: 'NebulaX', to: 'Andromeda', type: 'attack', time: '12s ago' },
-  { id: 2, from: 'Vortexal', to: 'NebulaX', type: 'raid', time: '2m ago' },
-  { id: 3, from: 'Andromeda', to: 'Singularis', type: 'attack', time: '4m ago' },
+  { id: 1, from: 'NebulaX', to: 'Andromeda', type: 'attack', time: 'just now' },
+  { id: 2, from: 'Vortexal', to: 'NebulaX', type: 'raid', time: '1m ago' },
+  { id: 3, from: 'Andromeda', to: 'Singularis', type: 'attack', time: '2m ago' },
 ]
 
 export default function RaidLog() {
   const [log, setLog] = useState(demoLog)
   const [explosion, setExplosion] = useState(null)
+
+  // Simulate incoming raids every 5 seconds
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const from = planets[Math.floor(Math.random() * planets.length)]
+      let to = from
+      while (to === from) {
+        to = planets[Math.floor(Math.random() * planets.length)]
+      }
+      setLog((prev) => [
+        {
+          id: prev[0].id + 1,
+          from,
+          to,
+          type: 'attack',
+          time: new Date().toLocaleTimeString()
+        },
+        ...prev.slice(0, 19)
+      ])
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [])
 
   // Demo: animate explosion on new log
   useEffect(() => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
+import WalletConnectionProvider from './providers/WalletConnectionProvider'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <WalletConnectionProvider>
+      <App />
+    </WalletConnectionProvider>
   </React.StrictMode>
 )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,4 +10,4 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <App />
     </WalletConnectionProvider>
   </React.StrictMode>
-)
+);

--- a/src/providers/WalletConnectionProvider.jsx
+++ b/src/providers/WalletConnectionProvider.jsx
@@ -1,0 +1,21 @@
+import { useMemo } from 'react'
+import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
+import { WalletAdapterNetwork } from '@solana/wallet-adapter-base'
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets'
+import { clusterApiUrl } from '@solana/web3.js'
+import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
+import '@solana/wallet-adapter-react-ui/styles.css'
+
+export default function WalletConnectionProvider({ children }) {
+  const network = WalletAdapterNetwork.Devnet
+  const endpoint = useMemo(() => clusterApiUrl(network), [network])
+  const wallets = useMemo(() => [new PhantomWalletAdapter()], [network])
+
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletModalProvider>{children}</WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  )
+}

--- a/src/providers/WalletConnectionProvider.jsx
+++ b/src/providers/WalletConnectionProvider.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base'
 import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets'


### PR DESCRIPTION
## Summary
- add setup instructions
- update wallet adapter versions so installation succeeds
- implement wallet connection with Phantom and show short address when connected
- simulate incoming raids for the feed

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dcb5c1ac483208e9eeccf30e3999f